### PR TITLE
Compatibility with PEXPrefix (and probably some other plugins)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.civchat2</groupId>
 	<artifactId>CivChat2</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2</version>
+	<version>1.2-2</version>
 	<name>CivChat2</name>
 	<url>https://github.com/Civcraft/CivChat2</url>
 

--- a/src/vg/civcraft/mc/civchat2/CivChat2Manager.java
+++ b/src/vg/civcraft/mc/civchat2/CivChat2Manager.java
@@ -299,7 +299,10 @@ public class CivChat2Manager {
 						//reciever is in differnt world dont send
 						continue;
 					} else {
-						receiver.sendMessage(String.format(event.getFormat(), sender.getName(), chatMessage));
+						if(event.getFormat().equals("<%1$s> %2$s")) {
+							event.setFormat(color + "%1$s: %2$s");
+						}
+						receiver.sendMessage(String.format(event.getFormat(), NameAPI.getCurrentName(sender.getUniqueId()), chatMessage));
 						/*receiver.sendMessage(sb.append(color) 
 												.append( NameAPI.getCurrentName(uuid)) 
 												.append(": ") 

--- a/src/vg/civcraft/mc/civchat2/CivChat2Manager.java
+++ b/src/vg/civcraft/mc/civchat2/CivChat2Manager.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 import vg.civcraft.mc.civchat2.database.DatabaseManager;
 import vg.civcraft.mc.civchat2.utility.CivChat2Config;
@@ -253,7 +254,9 @@ public class CivChat2Manager {
 	 * @param chatMessage Message to send
 	 * @param recipients Players in range to receive the message
 	 */
-	public void broadcastMessage(Player sender, String chatMessage, Set<Player> recipients) {
+	public void broadcastMessage(AsyncPlayerChatEvent event, Set<Player> recipients) {
+		Player sender = event.getPlayer();
+		String chatMessage = event.getMessage();
 		int range = config.getChatRange();
 		int height = config.getYInc();	
 		Location location = sender.getLocation();
@@ -296,11 +299,12 @@ public class CivChat2Manager {
 						//reciever is in differnt world dont send
 						continue;
 					} else {
-						receiver.sendMessage(sb.append(color) 
+						receiver.sendMessage(String.format(event.getFormat(), sender.getName(), chatMessage));
+						/*receiver.sendMessage(sb.append(color) 
 												.append( NameAPI.getCurrentName(uuid)) 
 												.append(": ") 
 												.append( chatMessage)
-												.toString());
+												.toString());*/
 						sb.delete(0, sb.length());
 					}
 				}

--- a/src/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
+++ b/src/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
@@ -117,7 +117,7 @@ public class CivChat2Listener implements Listener {
 		}
 		
 		CivChat2.debugmessage("PlayerChatEvent calling chatman.broadcastMessage()");
-		chatman.broadcastMessage(sender, chatMessage, asyncPlayerChatEvent.getRecipients());
+		chatman.broadcastMessage(asyncPlayerChatEvent, asyncPlayerChatEvent.getRecipients());
 	}
 	
 	


### PR DESCRIPTION
I made a small change so that for non-private messages, CivChat will respect format changes that have been made to the message by other plugins. This makes CivChat and PEXPrefix compatible. It also makes CivChat compatible with other plugins that change the format of chat messages. 

As an added side-effect: Previously, CivChat changed the format of messages from <{player}> {message} (like it is in vanilla) to {player}: {message}. The change I've made makes it so the format of broadcasted (non-private) chat messages is the way it would be in vanilla when the format is not being altered by other plugins. This is kind of necessary for CivChat to be compatible with other plugins that change the format of chat messages. If this side-effect is an issue for some reason, I could change it so that CivChat automatically changes the format of chat messages to CivChat's old message format, then other plugins with higher priority listeners can change it back (such a change would require that the priority of CivChat's AsyncPlayerChatEvent EventHandler be changed to something lower than its current EventPriority.MONITOR).
